### PR TITLE
Update poetry install shell script

### DIFF
--- a/{{cookiecutter.project_slug}}/backend/backend.dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/backend.dockerfile
@@ -3,7 +3,7 @@ FROM tiangolo/uvicorn-gunicorn-fastapi:python3.8
 WORKDIR /app/
 
 # Install Poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/1.4.2/install-poetry.py | POETRY_HOME=/opt/poetry python && \
     cd /usr/local/bin && \
     ln -s /opt/poetry/bin/poetry && \
     poetry config virtualenvs.create false

--- a/{{cookiecutter.project_slug}}/backend/celeryworker.dockerfile
+++ b/{{cookiecutter.project_slug}}/backend/celeryworker.dockerfile
@@ -3,7 +3,7 @@ FROM python:3.8
 WORKDIR /app/
 
 # Install Poetry
-RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | POETRY_HOME=/opt/poetry python && \
+RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/1.4.2/install-poetry.py | POETRY_HOME=/opt/poetry python && \
     cd /usr/local/bin && \
     ln -s /opt/poetry/bin/poetry && \
     poetry config virtualenvs.create false


### PR DESCRIPTION
The poetry install shell script has been renamed to install-poetry.sh. This PR will update the Dockerfile templates to point to the current tagged version of 1.4.2. 